### PR TITLE
Update the cache branch with the sorted-set branch

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,57 +1,10 @@
 import { Redis } from "@upstash/redis";
-
-export type Event = {
-  time?: number;
-  [key: string]: string | number | boolean | undefined;
-};
-
-class Key {
-  constructor(public readonly prefix: string, public readonly table: string, public readonly bucket: number) {}
-
-  public toString() {
-    return [this.prefix, this.table, this.bucket].join(":");
-  }
-  static fromString(key: string) {
-    const [prefix, table, bucket] = key.split(":");
-    return new Key(prefix, table, parseInt(bucket));
-  }
-}
-
-export type Window = `${number}${"s" | "m" | "h" | "d"}`;
-
-export type AnalyticsConfig = {
-  redis: Redis;
-  /**
-   * Configure the bucket size for analytics. All events inside the window will be stored inside
-   * the same bucket. This reduces the number of keys that need to be scanned when aggregating
-   * and reduces your cost.
-   *
-   * Must be either a string in the format of `1s`, `2m`, `3h`, `4d` or a number of milliseconds.
-   */
-  window: Window | number;
-  prefix?: string;
-
-  /**
-   * Configure the retention period for analytics. All events older than the retention period will
-   * be deleted. This reduces the number of keys that need to be scanned when aggregating.
-   *
-   * Can either be a string in the format of `1s`, `2m`, `3h`, `4d` or a number of milliseconds.
-   * 0, negative or undefined means that the retention is disabled.
-   *
-   * @default Disabled
-   *
-   * Buckets are evicted when they are read, not when they are written. This is much cheaper since
-   * it only requires a single command to ingest data.
-   */
-  retention?: Window | number
-  
-  /**
-   * Whether to initialize a cache. Cache is used in the `loadBuckets` method, which in turn is
-   * called in `count`, `aggregateBy` and `query` methods. This means that to only use `ingest`,
-   * there is no need to use cache.
-   */
-  cache?: boolean
-};
+import {
+  Event,
+  Key,
+  Window,
+  AnalyticsConfig
+} from "./types"
 
 class Cache<TValue> {
   private readonly cache: Map<string, { value: TValue; createdAt: number }>;

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -5,40 +5,11 @@ import {
   Window,
   AnalyticsConfig
 } from "./types"
-
-class Cache<TValue> {
-  private readonly cache: Map<string, { value: TValue; createdAt: number }>;
-  private readonly ttl: number;
-  constructor(ttl: number) {
-    this.cache = new Map();
-    this.ttl = ttl;
-
-    setInterval(() => {
-      const now = Date.now();
-      for (const [key, { createdAt }] of this.cache) {
-        if (now - createdAt > this.ttl) {
-          this.cache.delete(key);
-        }
-      }
-    }, this.ttl * 10);
-  }
-
-  public get(key: string): TValue | null {
-    const data = this.cache.get(key);
-    if (!data) {
-      return null;
-    }
-    if (Date.now() - data.createdAt > this.ttl) {
-      this.cache.delete(key);
-      return null;
-    }
-    return data.value;
-  }
-
-  public set(key: string, value: TValue) {
-    this.cache.set(key, { createdAt: Date.now(), value });
-  }
-}
+import {
+  aggregateHourScript,
+  getAllowedBlockedScript,
+  getMostAllowedBlockedScript
+} from "./scripts";
 
 export class Analytics {
   private readonly redis: Redis;
@@ -46,14 +17,11 @@ export class Analytics {
   private readonly bucketSize: number;
   private readonly retention?: number;
 
-  private readonly cache?: Cache<Record<string, number>>;
-
   constructor(config: AnalyticsConfig) {
     this.redis = config.redis;
     this.prefix = config.prefix ?? "@upstash/analytics";
     this.bucketSize = this.parseWindow(config.window);
     this.retention = config.retention ? this.parseWindow(config.retention) : undefined;
-    this.cache = config.cache ? new Cache(60000) : undefined;
   }
 
   private validateTableName(table: string) {
@@ -95,6 +63,13 @@ export class Analytics {
     }
   }
 
+  public getBucket(time?: number): number {
+    const bucketTime = time ?? Date.now();
+    // Bucket is a unix timestamp in milliseconds marking
+    // the beginning of a window
+    return Math.floor(bucketTime / this.bucketSize) * this.bucketSize;
+  }
+
   /**
    * Ingest a new event
    * @param table
@@ -104,248 +79,187 @@ export class Analytics {
     this.validateTableName(table);
     await Promise.all(
       events.map(async (event) => {
-        const time = event.time ?? Date.now();
-        // Bucket is a unix timestamp in milliseconds marking the beginning of a day
-        const bucket = Math.floor(time / this.bucketSize) * this.bucketSize;
+        const bucket = this.getBucket(event.time);
         const key = [this.prefix, table, bucket].join(":");
 
-        await this.redis.hincrby(
+        await this.redis.zincrby(
           key,
+          1,
           JSON.stringify({
             ...event,
             time: undefined,
-          }),
-          1,
-        );
+          })
+        )
       }),
     );
   }
 
-  private async loadBuckets(
+  public async aggregateBucket(
     table: string,
-    opts: {
-      scan?: boolean;
-      range: [number, number];
-    },
-  ): Promise<{ key: string; hash: Record<string, number> }[]> {
+    timestamp?: number,
+    redis?: Redis
+  ): Promise<{time: number, success: {true: number, false: number}}> {
     this.validateTableName(table);
-    const now = Date.now();
+    redis = redis ?? this.redis
 
-    const keys: string[] = [];
-    if (opts.scan) {
-      let cursor = 0;
-      const match = [this.prefix, table, "*"].join(":");
-      do {
-        const [nextCursor, found] = await this.redis.scan(cursor, {
-          match,
-        });
+    const bucket = this.getBucket(timestamp);
+    const key = [this.prefix, table, bucket].join(":");
 
-        cursor = nextCursor;
-        for (const key of found) {
-          const timestamp = parseInt(key.split(":").pop()!);
-          // Delete keys that are older than the retention period
-          if (this.retention && timestamp < now - this.retention) {
-            await this.redis.del(key);
-            continue;
-          }
-          // Take all the keys that at least overlap with the given range
-          if (timestamp >= opts.range[0] || timestamp <= opts.range[1]) {
-            keys.push(key);
-          }
-        }
-      } while (cursor !== 0);
-    } else {
-      let t = Math.floor(now / this.bucketSize) * this.bucketSize;
-      while (t > opts.range[1]) {
-        t -= this.bucketSize;
-      }
-      while (t >= opts.range[0]) {
-        keys.push([this.prefix, table, t].join(":"));
-        t -= this.bucketSize;
-      }
-    }
-    const loadKeys: string[] = [];
-    const buckets: { key: string; hash: Record<string, number> }[] = [];
-    for (const key of keys) {
-      if (this.cache) {
-        const cached = this.cache.get(key);
-        if (cached) {
-          buckets.push({
-            key,
-            hash: cached,
-          });
-        }
-      } else {
-        loadKeys.push(key);
-      }
-    }
+    const result = await this.redis.eval(
+      aggregateHourScript,
+      [key],
+      []
+    ) as number[];
 
-    const p = this.redis.pipeline();
-    for (const key of loadKeys) {
-      p.hgetall(key);
-    }
-    const res = loadKeys.length > 0 ? await p.exec<(Record<string, number> | null)[]>() : [];
-    for (let i = 0; i < loadKeys.length; i++) {
-      const key = loadKeys[i];
-      const hash = res[i];
-      if (hash && this.cache) {
-        this.cache.set(key, hash);
+    return {
+      time: bucket,
+      success: {
+        true: result[0],
+        false: result[1]
       }
-      buckets.push({
-        key,
-        hash: hash ?? {},
-      });
-    }
-
-    return buckets
-      .sort((a, b) => a.hash.time - b.hash.time)
-      .map((item) => ({
-        ...item,
-        hash: Object.fromEntries(Object.entries(item.hash).map((x) => [x[0], Number(x[1])])),
-      }));
+    };
   }
+
+  public async aggregateBuckets(
+    table: string,
+    bucketCount: number,
+    timestamp?: number
+  ): Promise<{time: number, success: {true: number, false: number}}[]> {
+    this.validateTableName(table);
+
+    let bucket = this.getBucket(timestamp)
+    const promises: Promise<{time: number, success: {true: number, false: number}}>[] = []
+  
+    
+    for (let i = 0; i < bucketCount; i += 1) {
+      promises.push(
+        this.aggregateBucket(table, bucket)
+      )
+      bucket = bucket - this.bucketSize
+    }
+
+    return Promise.all(promises)
+  }
+
+  public async aggregateBucketsWithPipeline(
+    table: string,
+    bucketCount: number,
+    timestamp?: number,
+    maxPipelineSize?: number
+  ): Promise<{time: number, success: {true: number, false: number}}[]> {
+    this.validateTableName(table);
+
+    maxPipelineSize = maxPipelineSize ?? 48
+    let bucket = this.getBucket(timestamp);
+    const buckets: number[] = []
+    let pipeline = this.redis.pipeline();
+    
+    const pipelinePromises: Promise<number[][]>[] = []
+    for (let i = 1; i <= bucketCount; i += 1) {
+      const key = [this.prefix, table, bucket].join(":");
+      pipeline.eval(
+        aggregateHourScript,
+        [key],
+        []
+      );
+      buckets.push(bucket)
+      bucket = bucket - this.bucketSize;
+
+      if (i % maxPipelineSize == 0 || i == bucketCount) {
+        pipelinePromises.push(pipeline.exec<number[][]>())
+        pipeline = this.redis.pipeline()
+      }
+    }
+    const bucketResults = (await Promise.all(pipelinePromises)).flat()
+    
+    return bucketResults.map((result, index) => {
+      return {
+        time: buckets[index],
+        success: {
+          true: result[0],
+          false: result[1]
+        }
+      }
+    })
+  }
+
+  public async getAllowedBlocked(
+    table: string,
+    timestampCount: number,
+    timestamp?: number,
+  ): Promise<
+    Record<string, {success: number, blocked: number}>
+  > {
+    this.validateTableName(table);
+    
+    const key = [this.prefix, table].join(":");
+    const bucket = this.getBucket(timestamp)
+
+    const result = await this.redis.eval(
+      getAllowedBlockedScript,
+      [key],
+      [bucket, this.bucketSize, timestampCount]
+    ) as (string | {identifier: string, success: boolean})[]
+
+
+    const allowedBlocked: Record<string, {success: number, blocked: number}> = {}
+
+    for (let i = 0; i < result.length; i += 2) {
+      const info = result[i] as {identifier: string, success: boolean}
+      const identifier: string = info.identifier;
+      const count = +result[i + 1] // cast string to number;
+
+      if (!allowedBlocked[identifier]) {
+        allowedBlocked[identifier] = {"success":0, "blocked":0}
+      }
+      allowedBlocked[identifier][info.success ? "success" : "blocked"] = count
+    }
+
+    return allowedBlocked
+  }
+
+  public async getMostAllowedBlocked(
+    table: string,
+    timestampCount: number,
+    itemCount: number,
+    timestamp?: number,
+  ): Promise<
+    {
+      allowed: {identifier: string, count: number}[],
+      blocked: {identifier: string, count: number}[]
+    }
+  > {
+    this.validateTableName(table);
+
+    const key = [this.prefix, table].join(":");
+    const bucket = this.getBucket(timestamp)
+
+    const result = await this.redis.eval(
+      getMostAllowedBlockedScript,
+      [key],
+      [bucket, this.bucketSize, timestampCount, itemCount]
+    ) as string[][]
+
+    return {
+      allowed: this.toDicts(result[0]),
+      blocked: this.toDicts(result[1])
+    }
+  }
+
   /**
-   * Returns the number of events per bucket
+   * convert ["a", 1, ...] to [{identifier: 1, count: 1}, ...]
+   * @param array
    */
-  async count(
-    table: string,
-    opts: {
-      range: [number, number];
-    },
-  ): Promise<{ time: number; count: number }[]> {
-    this.validateTableName(table);
-
-    const buckets = await this.loadBuckets(table, { range: opts.range });
-
-    return await Promise.all(
-      buckets.map(async ({ key, hash }) => {
-        const timestamp = parseInt(key.split(":").pop()!);
-        return {
-          time: timestamp,
-          count: Object.values(hash).reduce((acc, curr) => acc + curr, 0),
-        };
-      }),
-    );
-  }
-
-  /**
-   * Builds a timeseries of the aggreagated value
-   *
-   * @param aggregateBy - The field to aggregate by
-   * @param cutoff - Timestamp in milliseconds to limit the aggregation to `cutoff` until now
-   * @returns
-   */
-  async aggregateBy<TAggregateBy extends keyof Omit<Event, "time">>(
-    table: string,
-    aggregateBy: TAggregateBy,
-    opts: {
-      /**
-       * The range of timestamps to query. If not specified, all buckets are loaded.
-       * The range is inclusive.
-       * The first element is the start of the range, the second element is the end of the range.
-       *
-       * In milliseconds
-       */
-      range: [number, number];
-    },
-  ): Promise<({ time: number } & Record<string, Record<string, number>>)[]> {
-    this.validateTableName(table);
-
-    const buckets = await this.loadBuckets(table, { range: opts.range });
-
-    const days = await Promise.all(
-      buckets.map(async ({ key, hash }) => {
-        const day = { time: Key.fromString(key).bucket } as {
-          time: number;
-        } & Record<TAggregateBy, Record<string, number>>;
-
-        for (const [field, count] of Object.entries(hash)) {
-          const r = JSON.parse(field) as Record<TAggregateBy, unknown>;
-          for (const [k, v] of Object.entries(r) as [TAggregateBy, string][]) {
-            const agg = r[aggregateBy];
-            // @ts-ignore
-            if (!day[agg]) {
-              // @ts-ignore
-              day[agg] = {};
-            }
-            if (k === aggregateBy) {
-              continue;
-            }
-            // @ts-ignore
-            if (!day[agg][v]) {
-              // @ts-ignore
-              day[agg][v] = 0;
-            }
-            // @ts-ignore
-            day[agg][v] += count;
-          }
-        }
-        return day;
-      }),
-    );
-    return days;
-  }
-
-  async query<TWhere extends keyof Omit<Event, "time">, TFilter extends keyof Omit<Event, "time">>(
-    table: string,
-    opts: {
-      where?: Record<TWhere, unknown>;
-      filter?: TFilter[];
-      /**
-       * The range of timestamps to query.
-       * The range is inclusive.
-       * The first element is the start of the range, the second element is the end of the range.
-       *
-       * In milliseconds
-       */
-      range: [number, number];
-    },
-  ): Promise<{ time: number; [key: keyof Omit<Event, "time">]: number }[]> {
-    this.validateTableName(table);
-    const buckets = await this.loadBuckets(table, { range: opts.range });
-
-    const days = await Promise.all(
-      buckets.map(async ({ key, hash }) => {
-        const day = { time: Key.fromString(key).bucket } as { time: number } & {
-          [key: keyof Omit<Event, "time">]: Record<string, number>;
-        };
-
-        for (const [field, count] of Object.entries(hash)) {
-          const r = JSON.parse(field);
-
-          let skip = false;
-          if (opts?.where) {
-            for (const [requiredKey, requiredValue] of Object.entries(opts.where)) {
-              if (!(requiredKey in r)) {
-                skip = true;
-                break;
-              }
-              if (r[requiredKey] !== requiredValue) {
-                skip = true;
-                break;
-              }
-            }
-          }
-          if (skip) {
-            continue;
-          }
-          for (const [k, v] of Object.entries(r) as [string, string][]) {
-            // @ts-ignore
-            if (opts?.filter && !opts.filter.includes(k)) {
-              continue;
-            }
-            if (!day[k]) {
-              day[k] = {};
-            }
-            if (!day[k][v]) {
-              day[k][v] = 0;
-            }
-            day[k][v] += count;
-          }
-        }
-        return day;
-      }),
-    );
-    return days as any;
+  protected toDicts (array: (string | {identifier: string, success: boolean})[]) {
+    const dict: {identifier: string, count: number}[] = [];
+    for (let i = 0; i < array.length; i += 2) {
+        const info = array[i] as {identifier: string, success: boolean}
+        const count = +array[i + 1] // cast string to number;
+        dict.push({
+          identifier: info.identifier,
+          count: count
+        })
+    }
+    return dict;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./analytics";
+export { Aggregate } from "./types";

--- a/src/scripts.ts
+++ b/src/scripts.ts
@@ -58,12 +58,10 @@ while (true_count + false_count) < (num_elements * 2) and 1 <= i do
   if score > 0 then
     local element = result[i]
     if string.find(element, "success\\":true") and true_count < num_elements then
-      table.insert(true_group, element)
-      table.insert(true_group, score)
+      table.insert(true_group, {score, element})
       true_count = true_count + 1
     elseif string.find(element, "success\\":false") and false_count < num_elements then
-      table.insert(false_group, element)
-      table.insert(false_group, score)
+      table.insert(false_group, {score, element})
       false_count = false_count + 1
     end
   end

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,54 @@
+import { Redis } from "@upstash/redis";
+
+export type Event = {
+  time?: number;
+  [key: string]: string | number | boolean | undefined;
+};
+
+export class Key {
+  constructor(public readonly prefix: string, public readonly table: string, public readonly bucket: number) {}
+
+  public toString() {
+    return [this.prefix, this.table, this.bucket].join(":");
+  }
+  static fromString(key: string) {
+    const [prefix, table, bucket] = key.split(":");
+    return new Key(prefix, table, parseInt(bucket));
+  }
+}
+
+export type Window = `${number}${"s" | "m" | "h" | "d"}`;
+
+export type AnalyticsConfig = {
+  redis: Redis;
+  /**
+   * Configure the bucket size for analytics. All events inside the window will be stored inside
+   * the same bucket. This reduces the number of keys that need to be scanned when aggregating
+   * and reduces your cost.
+   *
+   * Must be either a string in the format of `1s`, `2m`, `3h`, `4d` or a number of milliseconds.
+   */
+  window: Window | number;
+  prefix?: string;
+
+  /**
+   * Configure the retention period for analytics. All events older than the retention period will
+   * be deleted. This reduces the number of keys that need to be scanned when aggregating.
+   *
+   * Can either be a string in the format of `1s`, `2m`, `3h`, `4d` or a number of milliseconds.
+   * 0, negative or undefined means that the retention is disabled.
+   *
+   * @default Disabled
+   *
+   * Buckets are evicted when they are read, not when they are written. This is much cheaper since
+   * it only requires a single command to ingest data.
+   */
+  retention?: Window | number
+  
+  /**
+   * Whether to initialize a cache. Cache is used in the `loadBuckets` method, which in turn is
+   * called in `count`, `aggregateBy` and `query` methods. This means that to only use `ingest`,
+   * there is no need to use cache.
+   */
+  cache?: boolean
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,3 +45,15 @@ export type AnalyticsConfig = {
    */
   retention?: Window | number
 };
+
+interface AggregateTime {
+  time: number;
+}
+
+interface AggregateGeneric {
+  [someFieldName: string]: {
+    [someFieldValue: string]: number;
+  };
+}
+
+export type Aggregate = AggregateTime & AggregateGeneric;

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,11 +44,4 @@ export type AnalyticsConfig = {
    * it only requires a single command to ingest data.
    */
   retention?: Window | number
-  
-  /**
-   * Whether to initialize a cache. Cache is used in the `loadBuckets` method, which in turn is
-   * called in `count`, `aggregateBy` and `query` methods. This means that to only use `ingest`,
-   * there is no need to use cache.
-   */
-  cache?: boolean
 };


### PR DESCRIPTION
Instead of using hash to store analytics, use sorted set and lua scripts.

Changes:
- cache is removed. It had no use other than functions for fetching analytics. This is already done in the Upstash console. No need to do it here.
- created types file and moved types there.
- defined scripts aggregateHourScript, getAllowedBlockedScript, getMostAllowedBlockedScript
- updated ingest method
- defined methods: getBucket, formatBucketAggregate, aggregateBuckets, aggregateBucket, aggregateBucketsWithPipeline, getAllowedBlocked, getMostAllowedBlocked